### PR TITLE
Request object for `post` and `put` operations

### DIFF
--- a/BogusDemoApiGateway/BogusDemoClient.cs
+++ b/BogusDemoApiGateway/BogusDemoClient.cs
@@ -30,29 +30,29 @@ internal class BogusDemoClient
 
     public async Task CreateDepartmentAsync(CreateDepartmentRequest request, CancellationToken ct)
     {
-        var url = $"{_endpointOption.CreateDepartmentEndpoint}?name={request.Name}";
-        using var response = await _httpClient.PutAsync(url, default, ct);
+        var content = JsonContent.Create(request);
+        using var response = await _httpClient.PutAsync(_endpointOption.CreateDepartmentEndpoint, content, ct);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task ChangeDepartmentNameAsync(ChangeDepartmentNameRequest request, CancellationToken ct)
     {
-        var url = $"{_endpointOption.ChangeDepartmentNameEndpoint}?id={request.Id}&name={request.Name}";
-        using var response = await _httpClient.PostAsync(url, default, ct);
+        var content = JsonContent.Create(request);
+        using var response = await _httpClient.PostAsync(_endpointOption.ChangeDepartmentNameEndpoint, content, ct);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task CreateRoomAsync(CreateRoomRequest request, CancellationToken ct)
     {
-        var url = $"{_endpointOption.CreateRoomEndpoint}?id={request.Id}&roomNumber= {request.RoomNumber}";
-        using var response = await _httpClient.PutAsync(url, default, ct);
+        var content = JsonContent.Create(request);
+        using var response = await _httpClient.PutAsync(_endpointOption.CreateRoomEndpoint, content, ct);
         response.EnsureSuccessStatusCode();
     }
 
     public async Task ChangeRoomAsync(ChangeRoomRequest request, CancellationToken ct)
     {
-        var url = $"{_endpointOption.ChangeRoomEndpoint}?departmentId={request.DepartmentId}&roomId={request.RoomId}&roomNumber={request.RoomNumber}";
-        using var response = await _httpClient.PostAsync(url, default, ct);
+        var content = JsonContent.Create(request);
+        using var response = await _httpClient.PostAsync(_endpointOption.ChangeRoomEndpoint, content, ct);
         response.EnsureSuccessStatusCode();
     }
 

--- a/BogusDemoApiGateway/BogusDemoClient.cs
+++ b/BogusDemoApiGateway/BogusDemoClient.cs
@@ -2,7 +2,7 @@
 
 namespace BogusDemoApiGateway;
 
-public class BogusDemoClient
+internal class BogusDemoClient
 {
     private readonly HttpClient _httpClient;
     private readonly EndpointOption _endpointOption;
@@ -28,31 +28,30 @@ public class BogusDemoClient
         return content;
     }
 
-    public async Task CreateDepartmentAsync(string name, CancellationToken ct)
+    public async Task CreateDepartmentAsync(CreateDepartmentRequest request, CancellationToken ct)
     {
-        var url = $"{_endpointOption.CreateDepartmentEndpoint}?name={name}";
+        var url = $"{_endpointOption.CreateDepartmentEndpoint}?name={request.Name}";
         using var response = await _httpClient.PutAsync(url, default, ct);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task ChangeDepartmentNameAsync(int id, string name, CancellationToken ct)
+    public async Task ChangeDepartmentNameAsync(ChangeDepartmentNameRequest request, CancellationToken ct)
     {
-        var url = $"{_endpointOption.ChangeDepartmentNameEndpoint}?id={id}&name={name}";
+        var url = $"{_endpointOption.ChangeDepartmentNameEndpoint}?id={request.Id}&name={request.Name}";
         using var response = await _httpClient.PostAsync(url, default, ct);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task CreateRoomAsync(int id, string roomNumber, CancellationToken ct)
+    public async Task CreateRoomAsync(CreateRoomRequest request, CancellationToken ct)
     {
-        var url = $"{_endpointOption.CreateRoomEndpoint}?id={id}&roomNumber={roomNumber}";
+        var url = $"{_endpointOption.CreateRoomEndpoint}?id={request.Id}&roomNumber= {request.RoomNumber}";
         using var response = await _httpClient.PutAsync(url, default, ct);
         response.EnsureSuccessStatusCode();
     }
 
-    public async Task ChangeRoomAsync(int departmentId, int roomId, string roomNumber,
-        CancellationToken ct)
+    public async Task ChangeRoomAsync(ChangeRoomRequest request, CancellationToken ct)
     {
-        var url = $"{_endpointOption.ChangeRoomEndpoint}?departmentId={departmentId}&roomId={roomId}&roomNumber={roomNumber}";
+        var url = $"{_endpointOption.ChangeRoomEndpoint}?departmentId={request.DepartmentId}&roomId={request.RoomId}&roomNumber={request.RoomNumber}";
         using var response = await _httpClient.PostAsync(url, default, ct);
         response.EnsureSuccessStatusCode();
     }
@@ -72,6 +71,14 @@ public class BogusDemoClient
     }
 }
 
-public record DepartmentDTO(int Id, string Name, IEnumerable<RoomDTO> Rooms);
+internal record DepartmentDTO(int Id, string Name, IEnumerable<RoomDTO> Rooms);
 
-public record RoomDTO(int Id, string RoomNumber);
+internal record RoomDTO(int Id, string RoomNumber);
+
+internal record CreateDepartmentRequest(string Name);
+
+internal record ChangeDepartmentNameRequest(int Id, string Name);
+
+internal record CreateRoomRequest(int Id, string RoomNumber);
+
+internal record ChangeRoomRequest(int DepartmentId, int RoomId, string RoomNumber);

--- a/BogusDemoApiGateway/Program.cs
+++ b/BogusDemoApiGateway/Program.cs
@@ -37,30 +37,31 @@ group.MapGet("get-departments", async (BogusDemoClient client, CancellationToken
     return TypedResults.Ok(content);
 });
 
-group.MapPut("create-department", async (string name, BogusDemoClient client, CancellationToken ct) =>
+group.MapPut("create-department", async (CreateDepartmentRequest request, BogusDemoClient client,
+    CancellationToken ct) =>
 {
-    await client.CreateDepartmentAsync(name, ct);
+    await client.CreateDepartmentAsync(request, ct);
     return TypedResults.Ok();
 });
 
-group.MapPost("change-department-name", async (int id, string name, BogusDemoClient client,
-    CancellationToken ct) =>
+group.MapPost("change-department-name", async (ChangeDepartmentNameRequest request,
+    BogusDemoClient client, CancellationToken ct) =>
 {
-    await client.ChangeDepartmentNameAsync(id, name, ct);
+    await client.ChangeDepartmentNameAsync(request, ct);
     return TypedResults.Ok();
 });
 
-group.MapPut("create-room", async (int id, string roomNumber, BogusDemoClient client,
+group.MapPut("create-room", async (CreateRoomRequest request, BogusDemoClient client,
     CancellationToken ct) =>
 {
-    await client.CreateRoomAsync(id, roomNumber, ct);
+    await client.CreateRoomAsync(request, ct);
     return TypedResults.Ok();
 });
 
-group.MapPost("change-room", async (int departmentId, int roomId, string roomNumber, BogusDemoClient client,
+group.MapPost("change-room", async (ChangeRoomRequest request, BogusDemoClient client,
     CancellationToken ct) =>
 {
-    await client.ChangeRoomAsync(departmentId, roomId, roomNumber, ct);
+    await client.ChangeRoomAsync(request, ct);
     return TypedResults.Ok();
 });
 


### PR DESCRIPTION
In this PR, I have replaced the `query string` parameters with request objects for `post` and `put` operations. This is the standard practice. The underline api also has done the same changes.